### PR TITLE
HTTPServerを構築

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/nekochans/kimono-app-api
 
 go 1.14
 
-require go.uber.org/zap v1.15.0
+require (
+	github.com/go-chi/chi v4.1.1+incompatible
+	go.uber.org/zap v1.15.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi v1.0.0 h1:s/kv1cTXfivYjdKJdyUzNGyAWZ/2t7duW1gKn5ivu+c=
+github.com/go-chi/chi v4.1.1+incompatible h1:MmTgB0R8Bt/jccxp+t6S/1VGIKdJw5J74CK/c9tTfA4=
+github.com/go-chi/chi v4.1.1+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/infrastructure/httputil/request.go
+++ b/infrastructure/httputil/request.go
@@ -4,16 +4,19 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-chi/chi/middleware"
 	"go.uber.org/zap"
 )
 
 func Log(l *zap.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
 			t1 := time.Now()
 			defer func() {
 				l.Info("Access",
-					zap.String("request_id", "-"), // TODO RequestIDを追加する
+					zap.String("request_id", middleware.GetReqID(r.Context())),
 					zap.String("request_remote", r.RemoteAddr),
 					zap.String("request_protocol", r.Proto),
 					zap.String("request_method", r.Method),
@@ -21,12 +24,13 @@ func Log(l *zap.Logger) func(next http.Handler) http.Handler {
 					zap.String("request_path", r.URL.Path),
 					zap.String("request_host", r.Host),
 					zap.String("request_referer", r.Referer()),
+					zap.Int("responses_status", ww.Status()),
+					zap.Int("response_length", ww.BytesWritten()),
 					zap.Duration("duration", time.Since(t1)),
-					// TODO レスポンスについてもログを出力する
 				)
 			}()
 
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(ww, r)
 
 		}
 		return http.HandlerFunc(fn)

--- a/infrastructure/httputil/request.go
+++ b/infrastructure/httputil/request.go
@@ -1,43 +1,34 @@
 package httputil
 
 import (
-	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"go.uber.org/zap"
-
-	"github.com/nekochans/kimono-app-api/infrastructure"
 )
 
-func Log(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logOpts := infrastructure.LoggerOptions{}
-		logger, err := infrastructure.NewLoggerFromOptions(logOpts)
-		defer logger.Sync()
+func Log(l *zap.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			t1 := time.Now()
+			defer func() {
+				l.Info("Access",
+					zap.String("request_id", "-"), // TODO RequestIDを追加する
+					zap.String("request_remote", r.RemoteAddr),
+					zap.String("request_protocol", r.Proto),
+					zap.String("request_method", r.Method),
+					zap.String("request_url", r.RequestURI),
+					zap.String("request_path", r.URL.Path),
+					zap.String("request_host", r.Host),
+					zap.String("request_referer", r.Referer()),
+					zap.Duration("duration", time.Since(t1)),
+					// TODO レスポンスについてもログを出力する
+				)
+			}()
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "[ERROR] Failed to create logger: %s\n", err)
-			os.Exit(1)
+			next.ServeHTTP(w, r)
+
 		}
-
-		t1 := time.Now()
-		defer func() {
-			logger.Info("Access",
-				zap.String("request_id", "-"), // TODO RequestIDを追加する
-				zap.String("request_remote", r.RemoteAddr),
-				zap.String("request_protocol", r.Proto),
-				zap.String("request_method", r.Method),
-				zap.String("request_url", r.RequestURI),
-				zap.String("request_path", r.URL.Path),
-				zap.String("request_host", r.Host),
-				zap.String("request_referer", r.Referer()),
-				zap.Duration("duration", time.Since(t1)),
-				// TODO レスポンスについてもログを出力する
-			)
-		}()
-
-		h.ServeHTTP(w, r)
-	})
+		return http.HandlerFunc(fn)
+	}
 }

--- a/infrastructure/server.go
+++ b/infrastructure/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nekochans/kimono-app-api/infrastructure/httputil"
 
 	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
 	"go.uber.org/zap"
 )
 
@@ -25,6 +26,7 @@ func NewServer(logger *zap.Logger) *HTTPServer {
 }
 
 func (s *HTTPServer) Middleware() {
+	s.router.Use(middleware.RequestID)
 	s.router.Use(httputil.Log(s.logger))
 }
 

--- a/infrastructure/server.go
+++ b/infrastructure/server.go
@@ -1,0 +1,44 @@
+package infrastructure
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/go-chi/chi"
+	"go.uber.org/zap"
+)
+
+type HTTPServer struct {
+	logger *zap.Logger
+	router *chi.Mux
+}
+
+func NewServer(logger *zap.Logger) *HTTPServer {
+	return &HTTPServer{
+		router: chi.NewRouter(),
+		logger: logger,
+	}
+}
+
+func (s *HTTPServer) Router() {
+	s.router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hello, HTTPサーバ")
+	})
+}
+
+func StartHTTPServer() {
+	logOpts := LoggerOptions{}
+	logger, err := NewLoggerFromOptions(logOpts)
+	defer logger.Sync()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Failed to create logger: %s\n", err)
+		os.Exit(1)
+	}
+	s := NewServer(logger)
+	s.Router()
+	log.Println("Starting app")
+	_ = http.ListenAndServe(":8888", s.router)
+}

--- a/infrastructure/server.go
+++ b/infrastructure/server.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/nekochans/kimono-app-api/infrastructure/httputil"
+
 	"github.com/go-chi/chi"
 	"go.uber.org/zap"
 )
@@ -20,6 +22,10 @@ func NewServer(logger *zap.Logger) *HTTPServer {
 		router: chi.NewRouter(),
 		logger: logger,
 	}
+}
+
+func (s *HTTPServer) Middleware() {
+	s.router.Use(httputil.Log(s.logger))
 }
 
 func (s *HTTPServer) Router() {
@@ -38,6 +44,7 @@ func StartHTTPServer() {
 		os.Exit(1)
 	}
 	s := NewServer(logger)
+	s.Middleware()
 	s.Router()
 	log.Println("Starting app")
 	_ = http.ListenAndServe(":8888", s.router)

--- a/main.go
+++ b/main.go
@@ -2,13 +2,6 @@ package main
 
 import "github.com/nekochans/kimono-app-api/infrastructure"
 
-//func handler(w http.ResponseWriter, r *http.Request) {
-//	fmt.Fprint(w, "Hello, HTTPサーバ")
-//}
-
 func main() {
 	infrastructure.StartHTTPServer()
-	//router := http.NewServeMux()
-	//router.HandleFunc("/", handler)
-	//http.ListenAndServe(":8888", httputil.Log(router))
 }

--- a/main.go
+++ b/main.go
@@ -1,18 +1,14 @@
 package main
 
-import (
-	"fmt"
-	"net/http"
+import "github.com/nekochans/kimono-app-api/infrastructure"
 
-	"github.com/nekochans/kimono-app-api/infrastructure/httputil"
-)
-
-func handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello, HTTPサーバ")
-}
+//func handler(w http.ResponseWriter, r *http.Request) {
+//	fmt.Fprint(w, "Hello, HTTPサーバ")
+//}
 
 func main() {
-	router := http.NewServeMux()
-	router.HandleFunc("/", handler)
-	http.ListenAndServe(":8888", httputil.Log(router))
+	infrastructure.StartHTTPServer()
+	//router := http.NewServeMux()
+	//router.HandleFunc("/", handler)
+	//http.ListenAndServe(":8888", httputil.Log(router))
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-api/issues/8

# Doneの定義
https://github.com/nekochans/kimono-app-api/issues/8 の完了条件を満たしていること

# 変更点概要
HTTPServerを構築。
ルーティングとMiddlewareを追加した。Middlewareでは、アクセスログの出力を行なっている。

また、ルーティングライブラリは[go-chi/chi](https://github.com/go-chi/chi)を導入。
選定理由は下記の通りであり、今回のAPIに適していると判断した。
- net/httpに準拠している
- Middlewareの機能が充実している
- ある程度メジャーである

現時点では、Handlerの構築はしていない。APIを追加するタイミングでHandlerを構築する。