### PR TITLE
make lintのCIに不備があったので修正

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,46 @@
+issues:
+  exclude-use-default: false
+
+linters-settings:
+  funlen:
+    lines: 65
+    statements: 40
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 
 ENV GO111MODULE=off
 
-ARG GOLANGCI_LINT_VERSION=v1.27.0
+ARG GOLANGCI_LINT_VERSION=v1.29.0
 
 RUN set -eux && \
   apk update && \
@@ -17,7 +17,8 @@ RUN set -eux && \
   chmod +x /go/bin/air && \
   go get -u github.com/go-delve/delve/cmd/dlv && \
   go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv && \
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION} && \
+  go get golang.org/x/tools/cmd/goimports
 
 ENV GO111MODULE on
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test-ci
+.PHONY: lint format test test-ci
 
 lint:
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@
 
 lint:
 	@go vet ./...
-	@gofmt -l -s -w .
 	@golangci-lint run ./...
+format:
+	@gofmt -l -s -w .
+	@goimports -w -l ./
 test:
 	@go test -v ./...
 test-ci:

--- a/README.md
+++ b/README.md
@@ -17,3 +17,37 @@
 [この記事](https://qiita.com/keitakn/items/f46347f871083356149b) のように `delve` を使ってデバックを行う場合は以下のスクリプトを実行して下さい。
 
 `./docker-compose-up-debug.sh`
+
+## Lintの実行
+
+`docker-compose exec api sh` でアプリケーション用のコンテナに入ります。
+
+`make lint` を実行して下さい。
+
+もしくは `docker-compose exec api make lint` でも実行出来ます。
+
+lintのルール等は以下を参考にして下さい。
+
+https://golangci-lint.run/usage/linters/
+
+ここで表示されたエラーは修正を行う必要があります。
+
+一部のエラー内容は後で解説する `make format` コマンドでも修正可能です。
+
+## ソースコードのフォーマット
+
+`docker-compose exec api sh` でアプリケーション用のコンテナに入ります。
+
+`make format` を実行して下さい。
+
+もしくは `docker-compose exec api make format` でも実行出来ます。
+
+このコマンドで自動修正されない物は自分で修正を行う必要があります。
+
+## テストの実行
+
+`docker-compose exec api sh` でアプリケーション用のコンテナに入ります。
+
+`make test` を実行します。
+
+もしくは `docker-compose exec api make test` でもテストを実行出来ます。

--- a/infrastructure/httputil/request.go
+++ b/infrastructure/httputil/request.go
@@ -31,7 +31,6 @@ func Log(l *zap.Logger) func(next http.Handler) http.Handler {
 			}()
 
 			next.ServeHTTP(ww, r)
-
 		}
 		return http.HandlerFunc(fn)
 	}

--- a/infrastructure/logger_test.go
+++ b/infrastructure/logger_test.go
@@ -1,8 +1,9 @@
 package infrastructure
 
 import (
-	"go.uber.org/zap/zapcore"
 	"testing"
+
+	"go.uber.org/zap/zapcore"
 )
 
 func TestCreateNewLoggerLogLevelIsDebug(t *testing.T) {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-api/issues/13

# Doneの定義
- https://github.com/nekochans/kimono-app-api/issues/13 の完了の定義を満たしている事

# 変更点概要
- lintとformatを別のコマンドとして定義
  - lintではコードのフォーマットを利用しないように変更
  - formatではgoimportsとgofmtを実行するように変更

# 補足情報

基本ほとんどのLinterを有効にしてあるが、一部例外的に無効化している物がある。

https://golangci-lint.run/usage/configuration/

- golint
ほとんどの警告が should have comment or be unexported .

パブリックなメソッドにコメントを書けという話だが、数が多すぎるのとそもそも必要性を感じないので無効化。

コメント書くよりもメソッド名を分かりやすくする努力のほうが大事だと思うという考えから。

あとそもそもgolint自体が開発止まっていて非推奨になっている。

https://twitter.com/sonatard/status/1268755758436343809?s=20

- stylecheck
ST1003: struct field Db should be DB のように DB や API 等の名称を使うように警告を出す。

しかしOpenAPIの定義からコードを生成する [oapi-codegen](https://github.com/deepmap/oapi-codegen) がキャメルケースでField名などを生成するので、これに合わせて全ての命名規則をキャメルケース、もしくはパスカルケースに統一しているので、このルールは無効にしてある。

今後 [oapi-codegen](https://github.com/deepmap/oapi-codegen) を使わないならこのルールを有効にしても良いかもだが、現状OpenAPI3.0に対応したCode Generatorで `github.com/go-chi/chi` に対応した物が他にないので  [oapi-codegen](https://github.com/deepmap/oapi-codegen)  を使うしかないかもしれない。

- rowserrcheck
DB.Prepare を使っている際の rows.Err must be checked の直し方がよく分からなかったので一旦無効にした。