### PR TITLE
https://git.io/linux_air が404になっておりインストールに失敗していたのでインストール方法を変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG GOLANGCI_LINT_VERSION=v1.29.0
 RUN set -eux && \
   apk update && \
   apk add --no-cache git curl make && \
-  curl -fLo /go/bin/air https://git.io/linux_air && \
-  chmod +x /go/bin/air && \
+  go get -u github.com/cosmtrek/air && \
+  go build -o /go/bin/air github.com/cosmtrek/air && \
   go get -u github.com/go-delve/delve/cmd/dlv && \
   go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv && \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION} && \


### PR DESCRIPTION
# issueURL
緊急対応だったのでなし

# Doneの定義
- https://github.com/nekochans/kimono-app-api/actions/runs/192885906 で起こっているDockerBuildの失敗が修正されている事

# 変更点概要
- https://git.io/linux_air が404になっていたので、go getを使ってインストール&Buildするように変更。

# 補足情報
air + GoLandで正常にデバッグ出来る事を確認済。