### PR TITLE
GitHub Actionsのjobにタイムアウトを設定

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build And Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-api/issues/20

# Doneの定義
https://github.com/nekochans/kimono-app-api/issues/20 の完了条件を満たしていること

# 変更点概要
GitHub ActionsのJobにタイムアウトを設定
時間は少し長めの10分を設定した

