### PR TITLE
ヘッダーからAuthorizationヘッダーを取得するミドルウェアを構築

### DIFF
--- a/infrastructure/httputil/auth.go
+++ b/infrastructure/httputil/auth.go
@@ -1,0 +1,22 @@
+package httputil
+
+import (
+	"net/http"
+)
+
+func Auth() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header
+			_, ok := header["Authorization"]
+			if !ok {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte("Authorization Error"))
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/infrastructure/httputil/auth.go
+++ b/infrastructure/httputil/auth.go
@@ -11,7 +11,7 @@ func Auth() func(next http.Handler) http.Handler {
 			_, ok := header["Authorization"]
 			if !ok {
 				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte("Authorization Error"))
+				_, _ = w.Write([]byte("Unauthorized"))
 				return
 			}
 

--- a/infrastructure/httputil/auth_test.go
+++ b/infrastructure/httputil/auth_test.go
@@ -32,7 +32,7 @@ func TestAuth(t *testing.T) {
 				req.Header.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64)")
 				return req
 			},
-			"Authorization Error",
+			"Unauthorized",
 			http.StatusUnauthorized,
 		},
 	}

--- a/infrastructure/httputil/auth_test.go
+++ b/infrastructure/httputil/auth_test.go
@@ -1,0 +1,58 @@
+package httputil
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func TestAuth(t *testing.T) {
+	tests := map[string]struct {
+		request            func() *http.Request
+		expectedResponse   string
+		expectedStatusCode int
+	}{
+		"OK response when including the Authorization header": {
+			func() *http.Request {
+				req, _ := http.NewRequestWithContext(context.TODO(), "GET", "/", nil)
+				req.Header.Add("Authorization", "aaa.aaa.aaa")
+				req.Header.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64)")
+				return req
+			},
+			"Hello, HTTPサーバ",
+			http.StatusOK,
+		},
+		"Error response when the Authorization header is not included": {
+			func() *http.Request {
+				req, _ := http.NewRequestWithContext(context.TODO(), "GET", "/", nil)
+				req.Header.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64)")
+				return req
+			},
+			"Authorization Error",
+			http.StatusUnauthorized,
+		},
+	}
+
+	for _, test := range tests {
+		w := httptest.NewRecorder()
+		r := chi.NewRouter()
+
+		r.Use(Auth())
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "Hello, HTTPサーバ")
+		})
+
+		r.ServeHTTP(w, test.request())
+
+		if w.Body.String() != test.expectedResponse {
+			t.Error("response Body was not the expected value")
+		}
+		if w.Code != test.expectedStatusCode {
+			t.Error("status code was not the expected value")
+		}
+	}
+}

--- a/infrastructure/server.go
+++ b/infrastructure/server.go
@@ -36,6 +36,7 @@ func NewServer(logger *zap.Logger) *HTTPServer {
 func (s *HTTPServer) Middleware() {
 	s.router.Use(middleware.RequestID)
 	s.router.Use(httputil.Log(s.logger))
+	s.router.Use(httputil.Auth())
 }
 
 func (s *HTTPServer) Router() {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-api/issues/17

# Doneの定義
- ヘッダーからAuthorizationヘッダーを取得するミドルウェアが構築されていること
- Authorizationヘッダーが含まれない場合、ステータスコード401を返すこと

# 変更点概要
- 認証処理を行うためのミドルウェアを作成
- Authミドルウェアに、リクエストヘッダーにAuthorizationが存在しない場合401を返す処理を追加

# 補足情報

#17 の対応として、まずJWTの検証処理を追加する。

## 検証方法

1. Authorazationヘッダーに JWTトークンが添付されていることを確認する
2. JWTの検証

なお、JWTの検証方法は下記を参考にする

[JSON ウェブトークンの検証](https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html)

それぞれの詳細は下記の通り。

### 1. ヘッダーに Authorizationが含まれていることを検証する (今回のPRの対応)

1. 認証に必要なパスへリクエスト時に認証処理を行うためにMiddlewareを構築する
2. Authorizationが含まれていることを確認する

    含まれていなかった場合、401を返す

### 2. JTWの検証 (別のPRで対応)

1. JWTの構造を確認する
    JWTの構造が適合しない場合、無効とする。

2. JWT署名を検証する

    署名は、ヘッダーとペイロードのハッシュ化された組み合わせ。

    1. IDトークンをデコード
    2. ローカルキーID(kid)をpublic kid を比較する

        a. JSON Web Key(JWK)をダウンロード。

        [`https://cognito-idp](https://cognito-idp/).{region}.amazonaws.com/{userPoolId}/.well-known/jwks.json.`

        b. JWTのkidと一致するkidをJWKから探す

    3. public keyを使用して署名を検証する。

3. クレームを検証する
    1. トークンの有効期限が切れていないこと
    2. audクレームがAmazon Cognito ユーザプールであること
    3. issuクレームがユーザプールと一致すること
    4. token_use クレームの検証
